### PR TITLE
fix(service): Extend stdio bridge creation timeout to 5 minutes

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -175,7 +175,7 @@ func (s *McpService) Start(logger xlog.Logger) error {
 	logger.Infof("Creating stdio-sse bridge for command: %s %s", s.Config.Command, strings.Join(s.Config.Args, " "))
 
 	// 创建stdio-sse桥接
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
 	bridgeInstance, err := bridge.NewStdioToSSEBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)


### PR DESCRIPTION
The external command for deploying sub-services (e.g., npx) was failing with a 'context deadline exceeded' error on systems with slower network connections, such as in a cloud container environment.

This was caused by a hardcoded 30-second timeout in service.go when initializing the stdio-to-SSE bridge. This commit increases the timeout to 5 minutes (300 seconds) to ensure the command has sufficient time to complete, improving the reliability of the deployment process.