### PR TITLE
Add stdio to HTTP stream bridge for MCP servers

### DIFF
--- a/bridge/stdio_to_http_stream.go
+++ b/bridge/stdio_to_http_stream.go
@@ -1,0 +1,240 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lucky-aeon/agentx/plugin-helper/xlog"
+	client "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	server "github.com/mark3labs/mcp-go/server"
+)
+
+// StdioToHTTPStreamBridge 创建一个将 stdio MCP 服务器桥接到 HTTP Stream 的转换器
+type StdioToHTTPStreamBridge struct {
+	stdioClient *client.Client
+	mcpServer   *server.MCPServer
+	*server.StreamableHTTPServer
+	mcpName string
+	logger  xlog.Logger
+}
+
+func NewStdioToHTTPStreamBridge(ctx context.Context, transport *transport.Stdio, mcpName string) (*StdioToHTTPStreamBridge, error) {
+	// 创建带有 mcpName 的专用 logger
+	logger := xlog.NewLogger("bridge").With("mcp_name", mcpName)
+
+	stdioClient := client.NewClient(transport)
+
+	logger.Info("Starting stdio client", "mcp_name", mcpName)
+	if err := stdioClient.Start(ctx); err != nil {
+		logger.Error("Failed to start stdio client", "error", err)
+		return nil, fmt.Errorf("failed to start stdio client: %w", err)
+	}
+
+	// 初始化 stdio 客户端
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "mcp-stdio-http-stream-bridge",
+		Version: "1.0.0",
+	}
+
+	initResult, err := stdioClient.Initialize(ctx, initRequest)
+	if err != nil {
+		logger.Error("Failed to initialize stdio client", "error", err)
+		return nil, fmt.Errorf("failed to initialize stdio client: %w", err)
+	}
+
+	logger.Info("Connected to stdio server",
+		"server_name", initResult.ServerInfo.Name,
+		"server_version", initResult.ServerInfo.Version,
+	)
+
+	// 2. 创建 MCP 服务器，作为桥接层
+	mcpServer := server.NewMCPServer(
+		"stdio-http-stream-bridge",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
+	)
+
+	bridge := &StdioToHTTPStreamBridge{
+		stdioClient: stdioClient,
+		mcpServer:   mcpServer,
+		mcpName:     mcpName,
+		logger:      logger,
+	}
+
+	// 3. 设置工具桥接
+	if err := bridge.setupToolBridge(ctx); err != nil {
+		bridge.logger.Warn("Failed to setup tool bridge", "error", err)
+	}
+
+	// 4. 设置资源桥接（如果支持的话）
+	if err := bridge.setupResourceBridge(ctx); err != nil {
+		bridge.logger.Warnf("Resource bridging failed (server may not support resources): %v", err)
+		// 不返回错误，继续启动服务器
+	}
+
+	// 5. 创建 StreamableHTTP 服务器包装 MCP 服务器
+	httpStreamServer := server.NewStreamableHTTPServer(
+		mcpServer,
+		server.WithEndpointPath(fmt.Sprintf("/%s", mcpName)),
+		server.WithStateLess(false), // 保持会话状态
+	)
+
+	bridge.StreamableHTTPServer = httpStreamServer
+
+	return bridge, nil
+}
+
+// setupToolBridge 设置工具桥接
+func (b *StdioToHTTPStreamBridge) setupToolBridge(ctx context.Context) error {
+	// 获取 stdio 服务器的工具列表
+	toolsRequest := mcp.ListToolsRequest{}
+	toolsResult, err := b.stdioClient.ListTools(ctx, toolsRequest)
+	if err != nil {
+		b.logger.Error("Failed to list tools from stdio server", "error", err)
+		return fmt.Errorf("failed to list tools from stdio server: %w", err)
+	}
+
+	b.logger.Info("Bridging tools from stdio server", "tool_count", len(toolsResult.Tools))
+
+	// 为每个工具创建桥接
+	for _, tool := range toolsResult.Tools {
+		// 复制工具定义
+		bridgedTool := tool
+		toolName := tool.Name
+
+		b.logger.Debug("Bridging tool", "tool_name", toolName)
+
+		// 创建工具处理器，将调用转发到 stdio 客户端
+		b.mcpServer.AddTool(bridgedTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			b.logger.Debug("Calling tool", "tool_name", toolName)
+
+			// 转发工具调用到 stdio 服务器
+			result, err := b.stdioClient.CallTool(ctx, request)
+			if err != nil {
+				b.logger.Error("Tool call failed", "tool_name", toolName, "error", err)
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to call tool %s: %v", toolName, err)), nil
+			}
+
+			b.logger.Debug("Tool call succeeded", "tool_name", toolName, result)
+			return result, nil
+		})
+	}
+
+	return nil
+}
+
+// setupResourceBridge 设置资源桥接
+func (b *StdioToHTTPStreamBridge) setupResourceBridge(ctx context.Context) error {
+	// 获取 stdio 服务器的资源列表
+	resourcesRequest := mcp.ListResourcesRequest{}
+	resourcesResult, err := b.stdioClient.ListResources(ctx, resourcesRequest)
+	if err != nil {
+		return fmt.Errorf("failed to list resources from stdio server: %w", err)
+	}
+
+	b.logger.Info("Bridging resources from stdio server", "resource_count", len(resourcesResult.Resources))
+
+	// 为每个资源创建桥接
+	for _, resource := range resourcesResult.Resources {
+		// 复制资源定义
+		bridgedResource := resource
+		resourceURI := resource.URI
+
+		b.logger.Debug("Bridging resource", "resource_uri", resourceURI)
+
+		// 创建资源处理器，将请求转发到 stdio 客户端
+		b.mcpServer.AddResource(bridgedResource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			b.logger.Debug("Reading resource", "resource_uri", resourceURI)
+
+			// 转发资源读取请求到 stdio 服务器
+			result, err := b.stdioClient.ReadResource(ctx, request)
+			if err != nil {
+				b.logger.Error("Resource read failed", "resource_uri", resourceURI, "error", err)
+				return nil, fmt.Errorf("failed to read resource %s: %w", resourceURI, err)
+			}
+
+			b.logger.Debug("Resource read succeeded", "resource_uri", resourceURI, result)
+			return result.Contents, nil
+		})
+	}
+
+	// 获取资源模板
+	templatesRequest := mcp.ListResourceTemplatesRequest{}
+	templatesResult, err := b.stdioClient.ListResourceTemplates(ctx, templatesRequest)
+	if err != nil {
+		b.logger.Error("Failed to list resource templates from stdio server", "error", err)
+		return fmt.Errorf("failed to list resource templates from stdio server: %w", err)
+	}
+
+	b.logger.Info("Bridging resource templates from stdio server", "template_count", len(templatesResult.ResourceTemplates))
+
+	// 为每个资源模板创建桥接
+	for _, template := range templatesResult.ResourceTemplates {
+		// 复制模板定义
+		bridgedTemplate := template
+		templateURI := template.URITemplate
+
+		b.logger.Debug("Bridging resource template", "template_uri", templateURI)
+
+		// 创建模板处理器
+		b.mcpServer.AddResourceTemplate(bridgedTemplate, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			b.logger.Debug("Reading resource template", "template_uri", templateURI)
+
+			// 转发资源读取请求到 stdio 服务器
+			result, err := b.stdioClient.ReadResource(ctx, request)
+			if err != nil {
+				b.logger.Error("Resource template read failed", "template_uri", templateURI, "error", err)
+				return nil, fmt.Errorf("failed to read resource template %+v: %w", templateURI, err)
+			}
+
+			b.logger.Debug("Resource template read succeeded", "template_uri", templateURI, result)
+			return result.Contents, nil
+		})
+	}
+	return nil
+}
+
+// Start 启动 HTTP Stream 服务器
+func (b *StdioToHTTPStreamBridge) Start(addr string) error {
+	b.logger.Info("Starting HTTP Stream bridge server", "address", addr)
+
+	if err := b.Ping(context.Background()); err != nil {
+		b.logger.Error("Failed to ping stdio server", "error", err)
+		return fmt.Errorf("failed to ping stdio server: %w", err)
+	}
+
+	b.logger.Info("HTTP Stream bridge server started successfully", "address", addr)
+	return b.StreamableHTTPServer.Start(addr)
+}
+
+// Close 关闭桥接器
+func (b *StdioToHTTPStreamBridge) Close() error {
+	b.logger.Info("Closing HTTP Stream bridge")
+
+	if b.stdioClient != nil {
+		b.stdioClient.Close()
+		b.logger.Debug("Stdio client closed")
+	}
+
+	err := b.StreamableHTTPServer.Shutdown(context.Background())
+	if err != nil {
+		b.logger.Error("Failed to shutdown HTTP Stream server", "error", err)
+		return fmt.Errorf("failed to shutdown HTTP Stream server: %w", err)
+	}
+
+	b.logger.Info("HTTP Stream bridge closed successfully")
+	return nil
+}
+
+func (b *StdioToHTTPStreamBridge) Ping(ctx context.Context) error {
+	if b.stdioClient == nil {
+		return fmt.Errorf("stdio client is not initialized")
+	}
+	return b.stdioClient.Ping(ctx)
+}

--- a/bridge/stdio_to_http_stream_test.go
+++ b/bridge/stdio_to_http_stream_test.go
@@ -1,0 +1,150 @@
+package bridge
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	client "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestHTTPStreamClient(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	pwd += "/testdata"
+	_ = os.Mkdir(pwd, 0755)
+	_ = os.WriteFile(pwd+"/test.txt", []byte("Hello, World!"), 0644)
+
+	// 1. 创建 stdio 客户端连接到文件系统服务器
+	stdioTransport := transport.NewStdio(
+		"npx",
+		nil, // 环境变量
+		"-y",
+		"@modelcontextprotocol/server-filesystem",
+		pwd,
+	)
+
+	t.Log("createHTTPStreamBridge")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	bridge, err := NewStdioToHTTPStreamBridge(ctx, stdioTransport, "filesystem")
+	if err != nil {
+		t.Fatalf("Failed to create bridge: %v", err)
+	}
+
+	// 启动 HTTP Stream 服务器
+	go func() {
+		t.Log("Starting HTTP Stream server on :8081...")
+		if err := bridge.Start(":8081"); err != nil {
+			t.Errorf("Failed to start HTTP Stream server: %v", err)
+		}
+	}()
+
+	t.Log("wait server starting....")
+	time.Sleep(1 * time.Second)
+	t.Log("server started")
+
+	// 创建 HTTP Stream 客户端连接到我们的桥接器
+	httpStreamTransport, err := transport.NewStreamableHTTP("http://localhost:8081/filesystem")
+	if err != nil {
+		t.Fatalf("Failed to create HTTP Stream transport: %v", err)
+	}
+
+	c := client.NewClient(httpStreamTransport)
+
+	// 启动客户端
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+	_ = c.Start(ctx2)
+
+	t.Log("Connecting to HTTP Stream bridge...")
+
+	// 初始化客户端
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "test-http-stream-client",
+		Version: "1.0.0",
+	}
+
+	initResult, err := c.Initialize(ctx2, initRequest)
+	if err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	defer func() {
+		_ = c.Close()
+	}()
+
+	t.Logf("Connected to bridge server: %s %s",
+		initResult.ServerInfo.Name,
+		initResult.ServerInfo.Version,
+	)
+
+	// 列出可用工具
+	t.Log("Listing available tools...")
+	toolsRequest := mcp.ListToolsRequest{}
+	toolsResult, err := c.ListTools(ctx2, toolsRequest)
+	if err != nil {
+		t.Fatalf("Failed to list tools: %v", err)
+	}
+
+	t.Logf("Found %d tools:", len(toolsResult.Tools))
+	for _, tool := range toolsResult.Tools {
+		t.Logf("- %s: %s", tool.Name, tool.Description)
+	}
+
+	// 测试调用一个工具
+	if len(toolsResult.Tools) > 0 {
+		// 测试 list_directory 工具
+		t.Log("Testing list_directory tool...")
+		callRequest := mcp.CallToolRequest{}
+		callRequest.Params.Name = "list_directory"
+		callRequest.Params.Arguments = map[string]any{
+			"path": pwd,
+		}
+
+		result, err := c.CallTool(ctx2, callRequest)
+		if err != nil {
+			t.Fatalf("Failed to call tool: %v", err)
+		} else {
+			t.Logf("Tool result: %+v", result.Content)
+		}
+
+		t.Log("Testing look test.txt file content...")
+		callRequest = mcp.CallToolRequest{}
+		callRequest.Params.Name = "read_file"
+		callRequest.Params.Arguments = map[string]any{
+			"path": pwd + "/test.txt",
+		}
+
+		result, err = c.CallTool(ctx2, callRequest)
+		if err != nil {
+			t.Fatalf("Failed to call tool: %v", err)
+		} else {
+			t.Logf("Tool result: %+v", result.Content)
+		}
+	}
+
+	// 测试资源桥接（如果支持的话）
+	t.Log("Listing available resources...")
+	resourcesRequest := mcp.ListResourcesRequest{}
+	resourcesResult, err := c.ListResources(ctx2, resourcesRequest)
+	if err != nil {
+		t.Logf("Resource listing not supported or failed (this is okay): %v", err)
+	} else {
+		t.Logf("Found %d resources:", len(resourcesResult.Resources))
+		for _, resource := range resourcesResult.Resources {
+			t.Logf("- %s: %s", resource.URI, resource.Name)
+		}
+	}
+
+	t.Log("HTTP Stream test completed successfully!")
+}


### PR DESCRIPTION
Implement StdioToHTTPStreamBridge to convert stdio-based MCP servers to HTTP streaming endpoints. Includes tool and resource bridging with comprehensive error handling and logging. Enables web clients to interact with stdio MCP servers through HTTP streams.