### PR TITLE
Use dynamic server info from init result in bridge constructors

### DIFF
--- a/bridge/sse_to_http_stream.go
+++ b/bridge/sse_to_http_stream.go
@@ -60,8 +60,8 @@ func NewSSEToHTTPStreamBridge(ctx context.Context, sseBaseURL string, mcpName st
 
 	// 2. 创建 MCP 服务器，作为桥接层
 	mcpServer := server.NewMCPServer(
-		"sse-http-stream-bridge",
-		"1.0.0",
+		initResult.ServerInfo.Name,
+		initResult.ServerInfo.Version,
 		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(true, true),
 		server.WithPromptCapabilities(true),

--- a/bridge/stdio_to_http_stream.go
+++ b/bridge/stdio_to_http_stream.go
@@ -53,8 +53,8 @@ func NewStdioToHTTPStreamBridge(ctx context.Context, transport *transport.Stdio,
 
 	// 2. 创建 MCP 服务器，作为桥接层
 	mcpServer := server.NewMCPServer(
-		"stdio-http-stream-bridge",
-		"1.0.0",
+		initResult.ServerInfo.Name,
+		initResult.ServerInfo.Version,
 		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(true, true),
 		server.WithPromptCapabilities(true),

--- a/bridge/stdio_to_sse.go
+++ b/bridge/stdio_to_sse.go
@@ -53,8 +53,8 @@ func NewStdioToSSEBridge(ctx context.Context, transport *transport.Stdio, mcpNam
 
 	// 2. 创建 MCP 服务器，作为桥接层
 	mcpServer := server.NewMCPServer(
-		"stdio-sse-bridge",
-		"1.0.0",
+		initResult.ServerInfo.Name,
+		initResult.ServerInfo.Version,
 		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(true, true),
 		server.WithPromptCapabilities(true),


### PR DESCRIPTION
Replace hardcoded server names and versions with values from the initialization result's ServerInfo in all three bridge types.