### PR TITLE
feat: support gateway protocol selection (SSE/StreamHTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 The MCP gateway is a reverse proxy server that forwards requests from clients to the MCP server or uses all MCP servers under the gateway through a unified portal.
 
+Supports two transport protocols (switchable at startup):
+
+- **SSE** (default, legacy MCP transport)
+- **Streamable HTTP** (MCP spec `2025-03-26`)
+
 ## Features
 
 - Deploy multiple MCP servers
@@ -11,6 +16,9 @@ The MCP gateway is a reverse proxy server that forwards requests from clients to
 - Use gateway to call MCP servers
 - Get all MCP servers' SSE streams
 - Get all MCP servers' tools
+- Streamable HTTP aggregated endpoint with session management via `Mcp-Session-Id` header
+- Dynamic capability aggregation (gateway only advertises capabilities that at least one downstream MCP supports)
+- API Key authentication (Bearer token / query param) and session-based authorization
 
 ## Installation
 
@@ -40,6 +48,70 @@ run self build docker container
 docker run -d --name mcp-gateway -p 8080:8080 mcp-gateway
 ```
 
+## Configuration
+
+The gateway reads `config.json` from the config directory (defaults to `./vm` when present, otherwise `.`). A minimal example:
+
+```json
+{
+    "LogLevel": 0,
+    "Bind": "[::]:8080",
+    "Auth": {
+        "Enabled": true,
+        "ApiKey": "123456"
+    },
+    "GatewayProtocol": "sse",
+    "McpServiceMgrConfig": {
+        "McpServiceRetryCount": 3
+    }
+}
+```
+
+Key fields:
+
+| Field                                   | Default       | Description                                                                        |
+| --------------------------------------- | ------------- | ---------------------------------------------------------------------------------- |
+| `Bind`                                  | `[::]:8080`   | Server listen address.                                                             |
+| `GatewayProtocol`                       | `sse`         | Transport protocol: `sse` or `streamhttp`. Also overridable via `--protocol` flag. |
+| `Auth.Enabled`                          | `true`        | Whether to enforce API Key authentication.                                         |
+| `Auth.ApiKey`                           | `123456`      | API Key used by clients.                                                           |
+| `SessionGCInterval`                     | `10s`         | Interval for garbage-collecting idle proxy sessions.                               |
+| `ProxySessionTimeout`                   | `1m`          | Timeout for idle proxy sessions before GC.                                         |
+| `McpServiceMgrConfig.McpServiceRetryCount` | `3`        | Max retries for a failed MCP service before marking it `failed`.                   |
+
+### Selecting the gateway protocol
+
+Either set `GatewayProtocol` in `config.json`:
+
+```json
+{ "GatewayProtocol": "streamhttp" }
+```
+
+Or pass the CLI flag (takes precedence):
+
+```bash
+./mcp-gateway --protocol=streamhttp
+```
+
+Valid values: `sse` (default) or `streamhttp`.
+
+## Authentication
+
+When `Auth.Enabled` is `true`, every request must present a credential. The gateway looks up the key in the following order:
+
+1. `Authorization: Bearer <ApiKey>` header
+2. `?api_key=<ApiKey>` query parameter
+3. `?sessionId=<id>` query parameter (only valid after a session has been created)
+4. `Mcp-Session-Id: <id>` header (Streamable HTTP clients)
+5. `X-Session-Id: <id>` header
+
+Typical patterns:
+
+- **Long-lived client (agent / Inspector)**: configure `Authorization: Bearer <ApiKey>` once; the gateway also threads the session identifier in responses so subsequent requests can skip the API Key if desired.
+- **Browser / debug use**: append `?api_key=<ApiKey>` to URLs.
+
+`initialize` (the first request in a session) **must** carry the API Key, since no session exists yet.
+
 ## API
 
 ### Deploy
@@ -65,7 +137,9 @@ Content-Type: application/json
 }
 ```
 
-### Use MCP
+### Use MCP (SSE Mode)
+
+> Available when `GatewayProtocol` is `sse` (default).
 
 #### GET SSE
 
@@ -94,7 +168,9 @@ Content-Type: application/json
 }
 ```
 
-### Use Gateway
+### Use Gateway (SSE Mode)
+
+> Available when `GatewayProtocol` is `sse` (default).
 
 网关和直连MCP的区别在于，只需要与网关交互，网关会自动将请求转发到对应的MCP服务器。在call 时，需要在method前面添加 `mcpServerName` 内容，标识该请求来自哪个 MCP 服务器。
 
@@ -198,3 +274,138 @@ Content-Type: application/json
 }
 ```
 
+### Use Gateway (Streamable HTTP Mode)
+
+> Available when `GatewayProtocol` is `streamhttp` (set via config or `--protocol=streamhttp`).
+>
+> Implements the MCP Streamable HTTP transport defined in spec `2025-03-26`. The gateway exposes a single aggregated endpoint `/stream` that accepts `POST`, `GET` and `DELETE`. Session identifiers are carried in the `Mcp-Session-Id` HTTP header.
+
+#### 1. Establish a session (initialize)
+
+```http
+POST /stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer 123456
+Accept: application/json, text/event-stream
+Content-Type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "my-client", "version": "1.0.0"}
+    }
+}
+```
+
+Response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Mcp-Session-Id: 7782f2f9-563c-4379-b961-df06e49e54c0
+
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "protocolVersion": "2025-03-26",
+        "serverInfo": {"name": "mcp-gateway", "version": "1.0.0"},
+        "capabilities": { /* OR-merged from all downstream MCP servers */ },
+        "instructions": "MCP Gateway aggregates multiple MCP servers. Tools are namespaced as <serverName>_<toolName>."
+    }
+}
+```
+
+Keep the returned `Mcp-Session-Id` and send it on every subsequent request.
+
+#### 2. Complete the handshake (notification)
+
+```http
+POST /stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer 123456
+Content-Type: application/json
+Mcp-Session-Id: 7782f2f9-563c-4379-b961-df06e49e54c0
+
+{"jsonrpc": "2.0", "method": "notifications/initialized"}
+```
+
+Response: `202 Accepted` (empty body).
+
+#### 3. Call tools or list resources
+
+```http
+POST /stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer 123456
+Accept: application/json, text/event-stream
+Content-Type: application/json
+Mcp-Session-Id: 7782f2f9-563c-4379-b961-df06e49e54c0
+
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+        "name": "{mcp-server-name}_get_current_time",
+        "arguments": {"timezone": "Asia/Seoul"}
+    }
+}
+```
+
+Aggregated tool names follow the pattern `<serverName>_<toolName>`, same rule as the SSE gateway mode.
+
+The response arrives synchronously in the HTTP response body:
+
+```json
+{"jsonrpc": "2.0", "id": 2, "result": { /* ... */ }}
+```
+
+Notifications (JSON-RPC messages without `id`) are answered with `202 Accepted` and forwarded asynchronously.
+
+#### 4. Subscribe to server-initiated events (optional)
+
+```http
+GET /stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer 123456
+Accept: text/event-stream
+Mcp-Session-Id: 7782f2f9-563c-4379-b961-df06e49e54c0
+```
+
+The gateway keeps the connection open and emits `event: message` frames for server → client JSON-RPC **requests** and **notifications** (e.g. progress updates, log messages). JSON-RPC **responses** are never pushed here — they are returned in the HTTP response of the originating `POST /stream` request.
+
+Lines starting with `:` are SSE keepalive comments and can be ignored.
+
+#### 5. Close the session
+
+```http
+DELETE /stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer 123456
+Mcp-Session-Id: 7782f2f9-563c-4379-b961-df06e49e54c0
+```
+
+Response: `200 OK`.
+
+#### Single-server passthrough
+
+In Streamable HTTP mode you can also reach an individual MCP server directly:
+
+```http
+POST /{mcp-server-name} HTTP/1.1
+GET  /{mcp-server-name} HTTP/1.1
+```
+
+The gateway forwards the request to the target MCP's `message` endpoint. Session management in this mode is the responsibility of the downstream server.
+
+#### Connecting with MCP Inspector
+
+1. In Inspector select **Transport Type**: `Streamable HTTP`.
+2. URL: `http://localhost:8080/stream`.
+3. Under *Configuration* → *Custom Headers*, add `Authorization: Bearer <ApiKey>`.
+4. Click **Connect**. The Inspector handles the `Mcp-Session-Id` exchange automatically.

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,0 +1,22 @@
+package bridge
+
+import (
+	"context"
+)
+
+type Bridge interface {
+	Start(addr string) error
+	Close() error
+	Ping(ctx context.Context) error
+}
+
+type SSEBridge interface {
+	Bridge
+	CompleteSseEndpoint() (string, error)
+	CompleteMessageEndpoint() (string, error)
+}
+
+type HTTPStreamBridge interface {
+	Bridge
+	CompleteHTTPStreamEndpoint() (string, error)
+}

--- a/bridge/stdio_to_http_stream.go
+++ b/bridge/stdio_to_http_stream.go
@@ -238,3 +238,7 @@ func (b *StdioToHTTPStreamBridge) Ping(ctx context.Context) error {
 	}
 	return b.stdioClient.Ping(ctx)
 }
+
+func (b *StdioToHTTPStreamBridge) CompleteHTTPStreamEndpoint() (string, error) {
+	return fmt.Sprintf("/%s", b.mcpName), nil
+}

--- a/bridge/stdio_to_sse.go
+++ b/bridge/stdio_to_sse.go
@@ -239,3 +239,11 @@ func (b *StdioToSSEBridge) Ping(ctx context.Context) error {
 	}
 	return b.stdioClient.Ping(ctx)
 }
+
+func (b *StdioToSSEBridge) CompleteSseEndpoint() (string, error) {
+	return fmt.Sprintf("/%s/sse", b.mcpName), nil
+}
+
+func (b *StdioToSSEBridge) CompleteMessageEndpoint() (string, error) {
+	return fmt.Sprintf("/%s/message", b.mcpName), nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	SessionGCInterval   time.Duration // Session GC间隔
 	ProxySessionTimeout time.Duration // Proxy Session 超时时间
 	McpServiceMgrConfig McpServiceMgrConfig
+	GatewayProtocol     string // 新增: "sse" | "streamhttp"
 }
 
 func InitConfig(cfgDir string) (cfg *Config, err error) {
@@ -59,7 +60,14 @@ func (c *Config) Default() {
 	if c.McpServiceMgrConfig.McpServiceRetryCount == 0 {
 		c.McpServiceMgrConfig.McpServiceRetryCount = 3
 	}
+	if c.GatewayProtocol == "" {
+		c.GatewayProtocol = "sse" // 默认 SSE
+	}
 
+}
+
+func (c *Config) IsStreamHTTP() bool {
+	return c.GatewayProtocol == "streamhttp"
 }
 
 func (c *Config) GetAuthConfig() *AuthConfig {

--- a/config/mcpserver.go
+++ b/config/mcpserver.go
@@ -2,11 +2,12 @@ package config
 
 // MCPServerConfig 定义单个MCP服务器的配置
 type MCPServerConfig struct {
-	Workspace string            `json:"workspace,omitempty"`
-	URL       string            `json:"url,omitempty"`
-	Command   string            `json:"command,omitempty"`
-	Args      []string          `json:"args,omitempty"`
-	Env       map[string]string `json:"env,omitempty"`
+	Workspace       string            `json:"workspace,omitempty"`
+	URL             string            `json:"url,omitempty"`
+	Command         string            `json:"command,omitempty"`
+	Args            []string          `json:"args,omitempty"`
+	Env             map[string]string `json:"env,omitempty"`
+	GatewayProtocol string            `json:"gateway_protocol,omitempty"`
 
 	LogConfig
 	McpServiceMgrConfig

--- a/docs/superpowers/plans/2026-04-17-gateway-protocol-design.md
+++ b/docs/superpowers/plans/2026-04-17-gateway-protocol-design.md
@@ -1,0 +1,397 @@
+# MCP Gateway 协议配置化实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 支持通过配置文件或命令行参数选择网关对外暴露的协议（SSE 或 StreamHTTP）
+
+**Architecture:**
+- 配置层：新增 `GatewayProtocol` 字段，支持命令行参数覆盖
+- 服务层：通过接口抽象桥接，支持选择 `StdioToSSEBridge` 或 `StdioToHTTPStreamBridge`
+- 路由层：根据配置注册对应端点
+
+**Tech Stack:** Go, Echo framework
+
+---
+
+## 文件结构
+
+| 文件 | 职责 |
+|------|------|
+| `config/config.go` | 配置结构体，新增 `GatewayProtocol` 字段 |
+| `main.go` | 命令行参数解析 |
+| `service/service.go` | 服务层，根据配置选择桥接类型 |
+| `bridge/bridge.go` | 新建，定义桥接接口抽象 |
+| `router/server.go` | 路由注册，根据协议注册对应端点 |
+
+---
+
+## Task 1: 配置层 - 添加 GatewayProtocol 字段
+
+**Files:**
+- Modify: `config/config.go:1-126`
+
+- [ ] **Step 1: 在 Config 结构体添加 GatewayProtocol 字段**
+
+在 `config/config.go` 的 `Config` 结构体中添加：
+
+```go
+type Config struct {
+    LogLevel            uint8
+    ConfigDirPath       string
+    Bind                string
+    Auth                *AuthConfig
+    SessionGCInterval   time.Duration
+    ProxySessionTimeout time.Duration
+    McpServiceMgrConfig McpServiceMgrConfig
+    GatewayProtocol     string  // 新增: "sse" | "streamhttp"
+}
+```
+
+- [ ] **Step 2: 在 Default() 方法中设置默认值**
+
+在 `config/config.go` 的 `Default()` 方法中添加：
+
+```go
+if c.GatewayProtocol == "" {
+    c.GatewayProtocol = "sse"  // 默认 SSE
+}
+```
+
+- [ ] **Step 3: 添加验证方法**
+
+在 `config/config.go` 添加：
+
+```go
+func (c *Config) IsStreamHTTP() bool {
+    return c.GatewayProtocol == "streamhttp"
+}
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add config/config.go
+git commit -m "feat(config): add GatewayProtocol field"
+```
+
+---
+
+## Task 2: 命令行参数解析
+
+**Files:**
+- Modify: `main.go:1-106`
+
+- [ ] **Step 1: 添加 flag 解析变量**
+
+在 `main.go` 添加：
+
+```go
+var protocolFlag string
+flag.StringVar(&protocolFlag, "protocol", "", "Gateway protocol: sse or streamhttp")
+```
+
+- [ ] **Step 2: 在 flag 解析后覆盖配置**
+
+在 `flag.Parse()` 后，`config.InitConfig()` 前添加：
+
+```go
+flag.Parse()
+// 如果命令行指定了 protocol，覆盖配置文件
+if protocolFlag != "" {
+    cfg.GatewayProtocol = protocolFlag
+}
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add main.go
+git commit -m "feat(main): add --protocol command line argument"
+```
+
+---
+
+## Task 3: 桥接接口抽象
+
+**Files:**
+- Create: `bridge/bridge.go`
+
+- [ ] **Step 1: 创建桥接接口**
+
+创建 `bridge/bridge.go`：
+
+```go
+package bridge
+
+import (
+    "context"
+)
+
+type Bridge interface {
+    Start(addr string) error
+    Close() error
+    Ping(ctx context.Context) error
+}
+
+type SSEBridge interface {
+    Bridge
+    CompleteSseEndpoint() (string, error)
+    CompleteMessageEndpoint() (string, error)
+}
+
+type HTTPStreamBridge interface {
+    Bridge
+    CompleteHTTPStreamEndpoint() (string, error)
+}
+```
+
+- [ ] **Step 2: 让 StdioToSSEBridge 实现 SSEBridge 接口**
+
+修改 `bridge/stdio_to_sse.go`，确保 `StdioToSSEBridge` 实现 `SSEBridge` 接口（已有方法签名匹配）。
+
+- [ ] **Step 3: 让 StdioToHTTPStreamBridge 实现 HTTPStreamBridge 接口**
+
+修改 `bridge/stdio_to_http_stream.go`，确保 `StdioToHTTPStreamBridge` 实现 `HTTPStreamBridge` 接口（已有方法签名匹配）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add bridge/bridge.go bridge/stdio_to_sse.go bridge/stdio_to_http_stream.go
+git commit -m "feat(bridge): add bridge interface abstraction"
+```
+
+---
+
+## Task 4: 服务层 - 支持协议选择
+
+**Files:**
+- Modify: `service/service.go:1-450`
+
+- [ ] **Step 1: 添加协议相关字段到 McpService**
+
+在 `McpService` 结构体中：
+
+```go
+type McpService struct {
+    Name    string
+    Config  config.MCPServerConfig
+    LogFile *os.File
+    logger  xlog.Logger
+    Port    int
+
+    portMgr PortManagerI
+
+    Status CmdStatus
+
+    RetryCount int
+    RetryMax   int
+
+    // 桥接 - 使用接口
+    bridge bridge.Bridge
+    isSSE  bool  // true = SSE bridge, false = HTTP Stream bridge
+
+    // ... 其他字段不变
+}
+```
+
+- [ ] **Step 2: 修改 Start() 方法支持协议选择**
+
+在 `service/service.go:137` 的 `Start()` 方法中，修改桥接创建逻辑：
+
+原代码（约 line 174-188）：
+```go
+// 使用stdio-sse桥接代替supergateway
+logger.Infof("Creating stdio-sse bridge for command: %s %s", s.Config.Command, strings.Join(s.Config.Args, " "))
+
+bridgeInstance, err := bridge.NewStdioToSSEBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+```
+
+修改为：
+```go
+// 根据配置选择桥接类型
+logger.Infof("Creating bridge for command: %s %s, protocol: %s", s.Config.Command, strings.Join(s.Config.Args, " "), s.Config.GatewayProtocol)
+
+var bridgeInstance bridge.Bridge
+if s.Config.GatewayProtocol == "streamhttp" {
+    logger.Infof("Using HTTP Stream bridge")
+    bridgeInstance, err = bridge.NewStdioToHTTPStreamBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+    if err == nil {
+        s.isSSE = false
+    }
+} else {
+    logger.Infof("Using SSE bridge")
+    bridgeInstance, err = bridge.NewStdioToSSEBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+    if err == nil {
+        s.isSSE = true
+    }
+}
+```
+
+- [ ] **Step 3: 修改 GetSSEUrl() 和 GetMessageUrl() 方法**
+
+约 line 324-340，根据 `isSSE` 返回对应 URL：
+
+```go
+func (s *McpService) GetSSEUrl() string {
+    if s.GetStatus() != Running {
+        return ""
+    }
+    if s.isSSE {
+        sseUrl, _ := s.bridge.(bridge.SSEBridge).CompleteSseEndpoint()
+        return s.GetUrl() + sseUrl
+    }
+    return ""
+}
+
+func (s *McpService) GetMessageUrl() string {
+    if s.GetStatus() != Running {
+        return ""
+    }
+    if s.isSSE {
+        mesUrl, _ := s.bridge.(bridge.SSEBridge).CompleteMessageEndpoint()
+        return s.GetUrl() + mesUrl
+    }
+    httpUrl, _ := s.bridge.(bridge.HTTPStreamBridge).CompleteHTTPStreamEndpoint()
+    return s.GetUrl() + httpUrl
+}
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add service/service.go
+git commit -m "feat(service): support protocol selection for bridge"
+```
+
+---
+
+## Task 5: 路由层 - 根据协议注册端点
+
+**Files:**
+- Modify: `router/server.go:1-104`
+
+- [ ] **Step 1: 添加协议判断和对应路由注册**
+
+在 `NewServerManager` 函数中，修改路由注册逻辑：
+
+原代码（约 line 30-34）：
+```go
+e.POST("/deploy", m.handleDeploy)
+e.DELETE("/delete", m.handleDeleteMcpService)
+e.GET("/sse", m.handleGlobalSSE)
+e.POST("/message", m.handleGlobalMessage)
+```
+
+修改为：
+```go
+e.POST("/deploy", m.handleDeploy)
+e.DELETE("/delete", m.handleDeleteMcpService)
+
+if cfg.IsStreamHTTP() {
+    // StreamHTTP 模式
+    e.GET("/:service", m.handleStreamHTTP)
+    e.POST("/:service", m.handleStreamHTTP)
+} else {
+    // SSE 模式（默认）
+    e.GET("/sse", m.handleGlobalSSE)
+    e.POST("/message", m.handleGlobalMessage)
+}
+```
+
+- [ ] **Step 2: 实现 handleStreamHTTP 处理函数**
+
+在 `router/server.go` 或新建 `router/streamhttp.go` 添加：
+
+```go
+func (m *ServerManager) handleStreamHTTP(c echo.Context) error {
+    xl := xlog.NewLogger("STREAMHTTP")
+    serviceName := c.Param("service")
+    workspace := utils.GetWorkspace(c, service.DefaultWorkspace)
+
+    instance, err := m.mcpServiceMgr.GetMcpService(xl, service.NameArg{
+        Server:    serviceName,
+        Workspace: workspace,
+    })
+    if err != nil {
+        return c.String(http.StatusNotFound, "Service not found")
+    }
+
+    targetURL := instance.GetMessageUrl()
+    if targetURL == "" {
+        return c.String(http.StatusServiceUnavailable, "Service not available")
+    }
+
+    // 转发请求到后端
+    req, err := http.NewRequest(c.Request().Method, targetURL, c.Request().Body)
+    if err != nil {
+        return err
+    }
+    for k, v := range c.Request().Header {
+        req.Header[k] = v
+    }
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+
+    for k, v := range resp.Header {
+        c.Response().Header()[k] = v
+    }
+    c.Response().WriteHeader(resp.StatusCode)
+    _, err = io.Copy(c.Response().Writer, resp.Body)
+    return err
+}
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add router/server.go
+git commit -m "feat(router): add StreamHTTP endpoint support"
+```
+
+---
+
+## Task 6: 集成测试
+
+- [ ] **Step 1: 验证 SSE 模式（默认）**
+
+```bash
+go run main.go &
+sleep 2
+curl -s http://localhost:8005/services | jq .
+```
+
+- [ ] **Step 2: 验证 StreamHTTP 模式**
+
+```bash
+pkill -f "mcp-gateway"
+go run main.go --protocol=streamhttp &
+sleep 2
+curl -s http://localhost:8005/services | jq .
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add -A
+git commit -m "test: verify protocol switching works"
+```
+
+---
+
+## 总结
+
+| Task | 内容 |
+|------|------|
+| 1 | 配置层添加 GatewayProtocol 字段 |
+| 2 | 命令行参数解析 |
+| 3 | 桥接接口抽象 |
+| 4 | 服务层支持协议选择 |
+| 5 | 路由层根据协议注册端点 |
+| 6 | 集成测试 |
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-17-gateway-protocol-design.md`.**

--- a/docs/superpowers/specs/2026-04-17-gateway-protocol-design.md
+++ b/docs/superpowers/specs/2026-04-17-gateway-protocol-design.md
@@ -1,0 +1,60 @@
+# MCP Gateway 协议配置化设计
+
+## 概述
+
+MCP Gateway 目前对外只暴露 SSE 协议，计划支持通过配置选择 SSE 或 StreamHTTP 协议对外暴露。
+
+## 需求
+
+- 支持启动时指定网关对外暴露的协议（SSE 或 StreamHTTP）
+- 支持配置文件和命令行参数两种配置方式
+- 命令行参数优先级高于配置文件
+
+## 设计
+
+### 配置项
+
+**配置文件 (`config.json`)** 新增字段：
+```json
+{
+  "GatewayProtocol": "sse"  // 或 "streamhttp"
+}
+```
+
+**命令行参数**：
+```
+--protocol=sse
+--protocol=streamhttp
+```
+
+### 优先级
+
+命令行参数 > 配置文件 > 默认值(sse)
+
+### 涉及的端点
+
+**SSE 模式**：
+- `GET /sse` - 全局SSE事件流
+- `POST /message` - 全局消息
+- `/{serviceName}/sse` - 单服务SSE
+- `/{serviceName}/message` - 单服务消息
+
+**StreamHTTP 模式**：
+- `POST /{serviceName}` - 单服务 StreamHTTP 调用
+- `GET /{serviceName}` - 单服务 StreamHTTP 调用
+
+### 文件修改
+
+| 文件 | 修改内容 |
+|------|----------|
+| `config/config.go` | 添加 `GatewayProtocol` 字段 |
+| `main.go` | 添加命令行参数解析 |
+| `router/server.go` | 根据协议注册对应端点 |
+| `service/service.go` | 根据协议选择 `StdioToSSEBridge` 或 `StdioToHTTPStreamBridge` |
+
+## 实现步骤
+
+1. **配置层**：在 `Config` 结构体添加 `GatewayProtocol` 字段，解析命令行 `--protocol` 参数
+2. **服务层**：`McpService` 根据配置选择桥接类型
+3. **路由层**：`ServerManager` 根据配置注册对应端点
+4. **默认值**：未配置时默认使用 SSE 保持向后兼容

--- a/main.go
+++ b/main.go
@@ -30,11 +30,11 @@ func main() {
 	}
 	flag.Parse()
 	cfg, err := config.InitConfig(cfgDir)
-	if protocolFlag != "" {
-		cfg.GatewayProtocol = protocolFlag
-	}
 	if err != nil {
 		panic(fmt.Errorf("failed to init config: %w", err))
+	}
+	if protocolFlag != "" {
+		cfg.GatewayProtocol = protocolFlag
 	}
 	defer func() {
 		cfg.SaveConfig()

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -20,11 +21,18 @@ import (
 )
 
 func main() {
+	var protocolFlag string
+	flag.StringVar(&protocolFlag, "protocol", "", "Gateway protocol: sse or streamhttp")
+
 	cfgDir := "./vm"
 	if _, err := os.Stat(cfgDir); os.IsNotExist(err) {
 		cfgDir = "."
 	}
+	flag.Parse()
 	cfg, err := config.InitConfig(cfgDir)
+	if protocolFlag != "" {
+		cfg.GatewayProtocol = protocolFlag
+	}
 	if err != nil {
 		panic(fmt.Errorf("failed to init config: %w", err))
 	}

--- a/middleware_impl/auth.go
+++ b/middleware_impl/auth.go
@@ -22,7 +22,9 @@ func NewAuthMiddleware(cfg *config.Config) *AuthMiddleware {
 
 func (m *AuthMiddleware) GetKeyAuthConfig() middleware.KeyAuthConfig {
 	return middleware.KeyAuthConfig{
-		KeyLookup: "header:Authorization:Bearer ,query:api_key,query:sessionId", // 从Header或Query获取
+		// 从 Header 或 Query 获取。新增 Mcp-Session-Id / X-Session-Id 以兼容
+		// Streamable HTTP 客户端（session 走 header）。
+		KeyLookup: "header:Authorization:Bearer ,query:api_key,query:sessionId,header:Mcp-Session-Id,header:X-Session-Id",
 		Validator: m.KeyAuthValidator,
 		ErrorHandler: func(err error, c echo.Context) error {
 			return c.JSON(http.StatusUnauthorized, map[string]any{"code": 401, "msg": errs.ErrAuthFailed.Error()})
@@ -46,7 +48,7 @@ func (m *AuthMiddleware) KeyAuthValidator(key string, c echo.Context) (bool, err
 
 	checkSession := false
 	switch realPath {
-	case "/sse", "/message":
+	case "/sse", "/message", "/stream":
 		checkSession = true
 	default:
 		if strings.Contains(realPath, "/message") {
@@ -55,8 +57,14 @@ func (m *AuthMiddleware) KeyAuthValidator(key string, c echo.Context) (bool, err
 	}
 
 	if checkSession {
-		// 检查session
-		if c.QueryParam("sessionId") != "" { // 如果是session，直接放行
+		// 检查session：query 和 header 均可放行，兼容 SSE 与 Streamable HTTP 两种协议
+		if c.QueryParam("sessionId") != "" {
+			return true, nil
+		}
+		if c.Request().Header.Get("Mcp-Session-Id") != "" {
+			return true, nil
+		}
+		if c.Request().Header.Get("X-Session-Id") != "" {
 			return true, nil
 		}
 		return false, nil

--- a/router/server.go
+++ b/router/server.go
@@ -34,7 +34,10 @@ func NewServerManager(cfg config.Config, e *echo.Echo) *ServerManager {
 	if m.cfg.IsStreamHTTP() {
 		e.GET("/:service", m.handleStreamHTTP)
 		e.POST("/:service", m.handleStreamHTTP)
+		// 全局 Streamable HTTP 聚合入口，按 MCP 2025-03-26 规范实现
 		e.POST("/stream", m.handleGlobalStreamHTTP)
+		e.GET("/stream", m.handleGlobalStreamHTTP)
+		e.DELETE("/stream", m.handleGlobalStreamHTTP)
 	} else {
 		e.GET("/sse", m.handleGlobalSSE)          // 全局SSE WIP
 		e.POST("/message", m.handleGlobalMessage) // 全局消息 WIP

--- a/router/server.go
+++ b/router/server.go
@@ -28,10 +28,16 @@ func NewServerManager(cfg config.Config, e *echo.Echo) *ServerManager {
 	}
 
 	// 注册路由
-	e.POST("/deploy", m.handleDeploy)                         // 部署服务
-	e.DELETE("/delete", m.handleDeleteMcpService)             // 删除服务
-	e.GET("/sse", m.handleGlobalSSE)                          // 全局SSE WIP
-	e.POST("/message", m.handleGlobalMessage)                 // 全局消息 WIP
+	e.POST("/deploy", m.handleDeploy)             // 部署服务
+	e.DELETE("/delete", m.handleDeleteMcpService) // 删除服务
+
+	if m.cfg.IsStreamHTTP() {
+		e.GET("/:service", m.handleStreamHTTP)
+		e.POST("/:service", m.handleStreamHTTP)
+	} else {
+		e.GET("/sse", m.handleGlobalSSE)          // 全局SSE WIP
+		e.POST("/message", m.handleGlobalMessage) // 全局消息 WIP
+	}
 	e.GET("/services", m.handleGetAllServices)                // 获取所有服务
 	e.GET("/services/:name/health", m.handleGetServiceHealth) // 获取服务健康状态
 

--- a/router/server.go
+++ b/router/server.go
@@ -34,6 +34,7 @@ func NewServerManager(cfg config.Config, e *echo.Echo) *ServerManager {
 	if m.cfg.IsStreamHTTP() {
 		e.GET("/:service", m.handleStreamHTTP)
 		e.POST("/:service", m.handleStreamHTTP)
+		e.POST("/stream", m.handleGlobalStreamHTTP)
 	} else {
 		e.GET("/sse", m.handleGlobalSSE)          // 全局SSE WIP
 		e.POST("/message", m.handleGlobalMessage) // 全局消息 WIP

--- a/router/streamhttp.go
+++ b/router/streamhttp.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
@@ -49,4 +50,38 @@ func (m *ServerManager) handleStreamHTTP(c echo.Context) error {
 	c.Response().WriteHeader(resp.StatusCode)
 	_, err = io.Copy(c.Response().Writer, resp.Body)
 	return err
+}
+
+func (m *ServerManager) handleGlobalStreamHTTP(c echo.Context) error {
+	xl := xlog.NewLogger("GLOBAL-STREAMHTTP")
+	workspace := utils.GetWorkspace(c, service.DefaultWorkspace)
+	querySessionId, err := utils.GetSession(c)
+	if err != nil {
+		querySessionId = ""
+	}
+
+	var session *service.Session
+	var exists bool
+	if querySessionId != "" {
+		session, exists = m.mcpServiceMgr.GetProxySession(xl, service.NameArg{
+			Workspace: workspace,
+			Session:   querySessionId,
+		})
+		if !exists {
+			return c.String(http.StatusNotFound, "session not found")
+		}
+	} else {
+		session, err = m.mcpServiceMgr.CreateProxySession(xl, service.NameArg{
+			Workspace: workspace,
+			Session:   querySessionId,
+		})
+		if err != nil {
+			return c.String(http.StatusInternalServerError, err.Error())
+		}
+	}
+
+	c.Response().Header().Set("Content-Type", "application/json")
+	c.Response().WriteHeader(http.StatusOK)
+	c.Response().Write([]byte(fmt.Sprintf(`{"sessionId":"%s","endpoint":"/stream"}`, session.Id)))
+	return nil
 }

--- a/router/streamhttp.go
+++ b/router/streamhttp.go
@@ -1,0 +1,52 @@
+package router
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/lucky-aeon/agentx/plugin-helper/service"
+	"github.com/lucky-aeon/agentx/plugin-helper/utils"
+	"github.com/lucky-aeon/agentx/plugin-helper/xlog"
+)
+
+func (m *ServerManager) handleStreamHTTP(c echo.Context) error {
+	xl := xlog.NewLogger("STREAMHTTP")
+	serviceName := c.Param("service")
+	workspace := utils.GetWorkspace(c, service.DefaultWorkspace)
+
+	instance, err := m.mcpServiceMgr.GetMcpService(xl, service.NameArg{
+		Server:    serviceName,
+		Workspace: workspace,
+	})
+	if err != nil {
+		return c.String(http.StatusNotFound, "Service not found")
+	}
+
+	targetURL := instance.GetMessageUrl()
+	if targetURL == "" {
+		return c.String(http.StatusServiceUnavailable, "Service not available")
+	}
+
+	req, err := http.NewRequest(c.Request().Method, targetURL, c.Request().Body)
+	if err != nil {
+		return err
+	}
+	for k, v := range c.Request().Header {
+		req.Header[k] = v
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		c.Response().Header()[k] = v
+	}
+	c.Response().WriteHeader(resp.StatusCode)
+	_, err = io.Copy(c.Response().Writer, resp.Body)
+	return err
+}

--- a/router/streamhttp.go
+++ b/router/streamhttp.go
@@ -1,16 +1,30 @@
 package router
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lucky-aeon/agentx/plugin-helper/service"
 	"github.com/lucky-aeon/agentx/plugin-helper/utils"
 	"github.com/lucky-aeon/agentx/plugin-helper/xlog"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
+const (
+	headerMcpSessionID       = "Mcp-Session-Id"
+	streamHTTPWaitTimeout    = 30 * time.Second
+	streamHTTPKeepAliveEvery = 30 * time.Second
+	methodNotificationsInit  = "notifications/initialized"
+)
+
+// handleStreamHTTP 单服务 Streamable HTTP 反向代理。
+// 仅把请求体按原样转给下游 MCP 服务暴露的 message 端点。
 func (m *ServerManager) handleStreamHTTP(c echo.Context) error {
 	xl := xlog.NewLogger("STREAMHTTP")
 	serviceName := c.Param("service")
@@ -52,36 +66,347 @@ func (m *ServerManager) handleStreamHTTP(c echo.Context) error {
 	return err
 }
 
+// handleGlobalStreamHTTP 是全局 /stream 聚合入口，实现 MCP Streamable HTTP 协议
+// (spec: 2025-03-26)。支持 POST/GET/DELETE 三种动作，会话通过
+// `Mcp-Session-Id` 响应/请求头传递。
 func (m *ServerManager) handleGlobalStreamHTTP(c echo.Context) error {
 	xl := xlog.NewLogger("GLOBAL-STREAMHTTP")
 	workspace := utils.GetWorkspace(c, service.DefaultWorkspace)
-	querySessionId, err := utils.GetSession(c)
+
+	switch c.Request().Method {
+	case http.MethodGet:
+		return m.streamHTTPEventStream(c, xl, workspace)
+	case http.MethodPost:
+		return m.streamHTTPHandlePost(c, xl, workspace)
+	case http.MethodDelete:
+		return m.streamHTTPHandleDelete(c, xl, workspace)
+	default:
+		c.Response().Header().Set("Allow", "GET, POST, DELETE")
+		return c.NoContent(http.StatusMethodNotAllowed)
+	}
+}
+
+// streamHTTPHandlePost 处理 POST /stream：
+//   - 无 Mcp-Session-Id 的 `initialize` 请求：创建新 session，响应头返回 session id，
+//     body 返回聚合后的 InitializeResult（不转发到下游，下游已在 CreateProxySession 内 initialize）。
+//   - `notifications/initialized` 通知：直接 202，无需转发。
+//   - notification（无 id）：异步转发后 202。
+//   - request（有 id）：订阅 session 事件通道，转发后等待 id 匹配的响应并同步返回。
+func (m *ServerManager) streamHTTPHandlePost(c echo.Context, xl xlog.Logger, workspace string) error {
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		querySessionId = ""
+		return writeJSONRPCError(c, http.StatusBadRequest, nil, -32700, "failed to read request body", err.Error())
 	}
 
-	var session *service.Session
-	var exists bool
-	if querySessionId != "" {
-		session, exists = m.mcpServiceMgr.GetProxySession(xl, service.NameArg{
-			Workspace: workspace,
-			Session:   querySessionId,
-		})
-		if !exists {
-			return c.String(http.StatusNotFound, "session not found")
-		}
-	} else {
-		session, err = m.mcpServiceMgr.CreateProxySession(xl, service.NameArg{
-			Workspace: workspace,
-			Session:   querySessionId,
-		})
-		if err != nil {
-			return c.String(http.StatusInternalServerError, err.Error())
-		}
+	peek, err := peekJSONRPC(body)
+	if err != nil {
+		return writeJSONRPCError(c, http.StatusBadRequest, nil, -32700, "parse error", err.Error())
 	}
 
-	c.Response().Header().Set("Content-Type", "application/json")
+	sessionID := c.Request().Header.Get(headerMcpSessionID)
+	// initialize 之外均要求携带 session id
+	if peek.Method == string(mcp.MethodInitialize) {
+		return m.streamHTTPHandleInitialize(c, xl, workspace, peek)
+	}
+
+	if sessionID == "" {
+		return writeJSONRPCError(c, http.StatusBadRequest, peek.ID, -32600, fmt.Sprintf("missing %s header", headerMcpSessionID), nil)
+	}
+
+	session, ok := m.mcpServiceMgr.GetProxySession(xl, service.NameArg{
+		Workspace: workspace,
+		Session:   sessionID,
+	})
+	if !ok {
+		// 404 会驱动客户端重新 initialize，对齐官方 client 行为
+		return c.String(http.StatusNotFound, "session not found")
+	}
+
+	// notifications/initialized 是 client → server 的通知，网关直接 ACK 即可
+	if peek.Method == methodNotificationsInit {
+		return c.NoContent(http.StatusAccepted)
+	}
+
+	// 通知：无 id，异步广播到下游
+	if peek.IsNotification() {
+		go func() {
+			if err := session.SendMessage(xl, body); err != nil {
+				xl.Warnf("send notification %s failed: %v", peek.Method, err)
+			}
+		}()
+		return c.NoContent(http.StatusAccepted)
+	}
+
+	// request：订阅后转发，等待 id 匹配的响应
+	return m.streamHTTPForwardAndWait(c, xl, session, body, peek)
+}
+
+// streamHTTPHandleInitialize 处理首次 initialize：创建 session，响应头带 session id，
+// body 返回聚合 InitializeResult（下游 MCP 的 initialize 已在 session 建立时完成）。
+func (m *ServerManager) streamHTTPHandleInitialize(c echo.Context, xl xlog.Logger, workspace string, peek jsonRPCPeek) error {
+	session, err := m.mcpServiceMgr.CreateProxySession(xl, service.NameArg{
+		Workspace: workspace,
+	})
+	if err != nil {
+		xl.Errorf("create session failed: %v", err)
+		return writeJSONRPCError(c, http.StatusInternalServerError, peek.ID, -32000, "failed to create session", err.Error())
+	}
+
+	c.Response().Header().Set(headerMcpSessionID, session.Id)
+	return writeJSONRPCResult(c, peek.ID, buildGatewayInitializeResult(session))
+}
+
+// streamHTTPForwardAndWait 在订阅 session 事件通道的前提下转发请求，并同步等待
+// 匹配 id 的响应消息。
+func (m *ServerManager) streamHTTPForwardAndWait(c echo.Context, xl xlog.Logger, session *service.Session, body []byte, peek jsonRPCPeek) error {
+	eventChan, closer := session.GetEventChanWithCloser()
+	defer closer()
+
+	sendErrCh := make(chan error, 1)
+	go func() {
+		sendErrCh <- session.SendMessage(xl, body)
+	}()
+
+	ctx, cancel := context.WithTimeout(c.Request().Context(), streamHTTPWaitTimeout)
+	defer cancel()
+
+	targetID := normalizeRawID(peek.ID)
+	var sendErr error
+	sendDone := false
+	for {
+		select {
+		case <-ctx.Done():
+			if sendErr != nil {
+				return writeJSONRPCError(c, http.StatusBadGateway, peek.ID, -32000, "forward failed", sendErr.Error())
+			}
+			return writeJSONRPCError(c, http.StatusGatewayTimeout, peek.ID, -32000, "timeout waiting for downstream response", nil)
+		case err := <-sendErrCh:
+			sendErr = err
+			sendDone = true
+			if err != nil {
+				xl.Warnf("SendMessage returned error: %v", err)
+			}
+		case evt, ok := <-eventChan:
+			if !ok {
+				if sendDone && sendErr != nil {
+					return writeJSONRPCError(c, http.StatusBadGateway, peek.ID, -32000, "forward failed", sendErr.Error())
+				}
+				return writeJSONRPCError(c, http.StatusInternalServerError, peek.ID, -32000, "session closed before response", nil)
+			}
+			if evt.Event != "" && evt.Event != "message" {
+				continue
+			}
+			if !responseMatchesID(evt.Data, targetID) {
+				continue
+			}
+			c.Response().Header().Set("Content-Type", "application/json")
+			c.Response().WriteHeader(http.StatusOK)
+			_, err := c.Response().Write([]byte(evt.Data))
+			return err
+		}
+	}
+}
+
+// streamHTTPEventStream 处理 GET /stream：长连接 SSE 流，把 session 的事件广播
+// 给当前客户端，常用于 server → client 的主动推送。
+func (m *ServerManager) streamHTTPEventStream(c echo.Context, xl xlog.Logger, workspace string) error {
+	sessionID := c.Request().Header.Get(headerMcpSessionID)
+	if sessionID == "" {
+		sessionID = c.QueryParam("sessionId")
+	}
+	if sessionID == "" {
+		return c.String(http.StatusBadRequest, fmt.Sprintf("missing %s header", headerMcpSessionID))
+	}
+
+	session, ok := m.mcpServiceMgr.GetProxySession(xl, service.NameArg{
+		Workspace: workspace,
+		Session:   sessionID,
+	})
+	if !ok {
+		return c.String(http.StatusNotFound, "session not found")
+	}
+
+	c.Response().Header().Set("Content-Type", "text/event-stream")
+	c.Response().Header().Set("Cache-Control", "no-cache")
+	c.Response().Header().Set("Connection", "keep-alive")
 	c.Response().WriteHeader(http.StatusOK)
-	c.Response().Write([]byte(fmt.Sprintf(`{"sessionId":"%s","endpoint":"/stream"}`, session.Id)))
-	return nil
+
+	w := c.Response().Writer
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return c.String(http.StatusInternalServerError, "streaming not supported")
+	}
+
+	eventChan, closer := session.GetEventChanWithCloser()
+	defer closer()
+
+	ping := time.NewTicker(streamHTTPKeepAliveEvery)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-c.Request().Context().Done():
+			xl.Infof("Client closed stream, sessionId=%s", sessionID)
+			return nil
+		case <-ping.C:
+			if _, err := fmt.Fprintf(w, ": keepalive\n\n"); err != nil {
+				return nil
+			}
+			flusher.Flush()
+		case evt, ok := <-eventChan:
+			if !ok {
+				return nil
+			}
+			// 规范: JSON-RPC responses 必须走原始 POST 的 HTTP response，不能
+			// 通过 GET SSE 流推送。GET 只承载 server→client 的 request/notification。
+			if isJSONRPCResponse(evt.Data) {
+				continue
+			}
+			eventName := evt.Event
+			if eventName == "" {
+				eventName = "message"
+			}
+			if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, evt.Data); err != nil {
+				return nil
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// streamHTTPHandleDelete 关闭 session。
+func (m *ServerManager) streamHTTPHandleDelete(c echo.Context, xl xlog.Logger, workspace string) error {
+	sessionID := c.Request().Header.Get(headerMcpSessionID)
+	if sessionID == "" {
+		return c.String(http.StatusBadRequest, fmt.Sprintf("missing %s header", headerMcpSessionID))
+	}
+	m.mcpServiceMgr.CloseProxySession(xl, service.NameArg{
+		Workspace: workspace,
+		Session:   sessionID,
+	})
+	return c.NoContent(http.StatusOK)
+}
+
+// --------- helpers ---------
+
+// jsonRPCPeek 用来从 request body 里快速抽取 JSON-RPC 关键字段，避免反序列化成
+// 完整结构体时受 params 中动态字段影响。
+type jsonRPCPeek struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+}
+
+// IsNotification 返回是否是 JSON-RPC notification（没有 id 字段或 id 为 null）。
+func (p jsonRPCPeek) IsNotification() bool {
+	if len(p.ID) == 0 {
+		return true
+	}
+	trimmed := bytes.TrimSpace(p.ID)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
+func peekJSONRPC(body []byte) (jsonRPCPeek, error) {
+	var p jsonRPCPeek
+	if err := json.Unmarshal(body, &p); err != nil {
+		return p, err
+	}
+	return p, nil
+}
+
+// normalizeRawID 去除两侧空白后返回 id 的规范化字节切片。
+func normalizeRawID(raw json.RawMessage) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return bytes.TrimSpace(raw)
+}
+
+// responseMatchesID 解析响应 body，判断其 id 是否与目标一致。
+func responseMatchesID(data string, target []byte) bool {
+	if len(target) == 0 {
+		return false
+	}
+	var peek struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(data), &peek); err != nil {
+		return false
+	}
+	return bytes.Equal(bytes.TrimSpace(peek.ID), target)
+}
+
+// isJSONRPCResponse 判断一条消息是否为 JSON-RPC response（含 result 或 error、
+// 有 id 且不含 method）。GET /stream 的 SSE 流只承载 server→client 的 request
+// 或 notification，不应该广播 response。
+func isJSONRPCResponse(data string) bool {
+	var peek struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &peek); err != nil {
+		return false
+	}
+	if peek.Method != "" {
+		return false
+	}
+	if len(bytes.TrimSpace(peek.ID)) == 0 {
+		return false
+	}
+	return len(peek.Result) > 0 || len(peek.Error) > 0
+}
+
+// writeJSONRPCResult 写入 2xx JSON-RPC response。
+func writeJSONRPCResult(c echo.Context, id json.RawMessage, result any) error {
+	payload := map[string]any{
+		"jsonrpc": mcp.JSONRPC_VERSION,
+		"result":  result,
+	}
+	if len(id) > 0 {
+		payload["id"] = json.RawMessage(id)
+	} else {
+		payload["id"] = nil
+	}
+	c.Response().Header().Set("Content-Type", "application/json")
+	return c.JSON(http.StatusOK, payload)
+}
+
+// writeJSONRPCError 写入 JSON-RPC 错误响应。statusCode 用于 HTTP 层，
+// JSON body 内是符合 JSON-RPC 规范的错误结构。
+func writeJSONRPCError(c echo.Context, statusCode int, id json.RawMessage, code int, message string, data any) error {
+	errObj := map[string]any{
+		"code":    code,
+		"message": message,
+	}
+	if data != nil {
+		errObj["data"] = data
+	}
+	payload := map[string]any{
+		"jsonrpc": mcp.JSONRPC_VERSION,
+		"error":   errObj,
+	}
+	if len(id) > 0 {
+		payload["id"] = json.RawMessage(id)
+	} else {
+		payload["id"] = nil
+	}
+	c.Response().Header().Set("Content-Type", "application/json")
+	return c.JSON(statusCode, payload)
+}
+
+// buildGatewayInitializeResult 构造网关层聚合的 InitializeResult。
+// capabilities 由 session 从已在线下游 MCP 的 initialize 结果 OR 合并而来，
+// 确保网关只向 client 声明至少有一个下游真的支持的能力。
+func buildGatewayInitializeResult(session *service.Session) *mcp.InitializeResult {
+	return &mcp.InitializeResult{
+		ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+		ServerInfo: mcp.Implementation{
+			Name:    "mcp-gateway",
+			Version: "1.0.0",
+		},
+		Capabilities: session.AggregateCapabilities(),
+		Instructions: "MCP Gateway aggregates multiple MCP servers. Tools are namespaced as <serverName>_<toolName>.",
+	}
 }

--- a/router/streamhttp_test.go
+++ b/router/streamhttp_test.go
@@ -1,0 +1,270 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/lucky-aeon/agentx/plugin-helper/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// 构造一条 POST /stream 请求并走 handler，返回 echo.Context 和 recorder。
+func buildStreamHTTPRequest(t *testing.T, method, body string, headers map[string]string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	var bodyReader *strings.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	var req *http.Request
+	if bodyReader != nil {
+		req = httptest.NewRequest(method, "/stream", bodyReader)
+	} else {
+		req = httptest.NewRequest(method, "/stream", nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	return c, rec
+}
+
+func newTestSession(id string) *service.Session {
+	return service.NewSession(id)
+}
+
+// --- Initialize: 创建 session，返回聚合 InitializeResult ---
+func TestGlobalStreamHTTP_Initialize_CreatesSessionAndReturnsResult(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+
+	// mock CreateProxySession 返回新 session
+	newSess := newTestSession("sess-init")
+	mockMgr.On("CreateProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Workspace == service.DefaultWorkspace
+	})).Return(newSess, nil).Once()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"inspector","version":"0.1"}}}`
+	c, rec := buildStreamHTTPRequest(t, http.MethodPost, body, nil)
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "sess-init", rec.Header().Get("Mcp-Session-Id"))
+
+	var resp map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "2.0", resp["jsonrpc"])
+	assert.EqualValues(t, 1, resp["id"])
+
+	result, ok := resp["result"].(map[string]any)
+	assert.True(t, ok, "result should be object")
+	assert.Equal(t, "2025-03-26", result["protocolVersion"])
+
+	serverInfo, ok := result["serverInfo"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "mcp-gateway", serverInfo["name"])
+
+	mockMgr.AssertExpectations(t)
+}
+
+// --- 非 initialize 必须带 Mcp-Session-Id ---
+func TestGlobalStreamHTTP_NonInitialize_MissingSessionReturns400(t *testing.T) {
+	srv, _ := createTestServerManager()
+
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`
+	c, rec := buildStreamHTTPRequest(t, http.MethodPost, body, nil)
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj, ok := resp["error"].(map[string]any)
+	assert.True(t, ok)
+	assert.EqualValues(t, -32600, errObj["code"])
+}
+
+// --- 非 initialize 带无效 session 返回 404 ---
+func TestGlobalStreamHTTP_NonInitialize_InvalidSessionReturns404(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+	mockMgr.On("GetProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Session == "unknown"
+	})).Return((*service.Session)(nil), false).Once()
+
+	body := `{"jsonrpc":"2.0","id":3,"method":"tools/list"}`
+	c, rec := buildStreamHTTPRequest(t, http.MethodPost, body, map[string]string{"Mcp-Session-Id": "unknown"})
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	mockMgr.AssertExpectations(t)
+}
+
+// --- notifications/initialized 直接 202 ---
+func TestGlobalStreamHTTP_NotificationsInitialized_Returns202(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+	sess := newTestSession("sess-n")
+	mockMgr.On("GetProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Session == "sess-n"
+	})).Return(sess, true).Once()
+
+	body := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	c, rec := buildStreamHTTPRequest(t, http.MethodPost, body, map[string]string{"Mcp-Session-Id": "sess-n"})
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Empty(t, rec.Body.String())
+
+	mockMgr.AssertExpectations(t)
+}
+
+// --- DELETE 关闭 session ---
+func TestGlobalStreamHTTP_Delete_ClosesSession(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+	mockMgr.On("CloseProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Session == "sess-del"
+	})).Return().Once()
+
+	c, rec := buildStreamHTTPRequest(t, http.MethodDelete, "", map[string]string{"Mcp-Session-Id": "sess-del"})
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	mockMgr.AssertExpectations(t)
+}
+
+// --- DELETE 缺失 header 返回 400 ---
+func TestGlobalStreamHTTP_Delete_MissingHeader(t *testing.T) {
+	srv, _ := createTestServerManager()
+	c, rec := buildStreamHTTPRequest(t, http.MethodDelete, "", nil)
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- 非 GET/POST/DELETE 返回 405 ---
+func TestGlobalStreamHTTP_MethodNotAllowed(t *testing.T) {
+	srv, _ := createTestServerManager()
+	c, rec := buildStreamHTTPRequest(t, http.MethodPut, "", nil)
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Contains(t, rec.Header().Get("Allow"), "POST")
+}
+
+// --- isJSONRPCResponse 过滤函数单元测试 ---
+func TestIsJSONRPCResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"result_response", `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`, true},
+		{"error_response", `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"x"}}`, true},
+		{"notification", `{"jsonrpc":"2.0","method":"notifications/message","params":{}}`, false},
+		{"request_with_id_and_method", `{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage"}`, false},
+		{"invalid_json", `not-json`, false},
+		{"response_with_string_id", `{"jsonrpc":"2.0","id":"abc","result":{}}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isJSONRPCResponse(tc.data))
+		})
+	}
+}
+
+// --- GET /stream 过滤 JSON-RPC response，只转发 request/notification ---
+func TestGlobalStreamHTTP_EventStream_DropsResponses(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+	sess := newTestSession("sess-stream")
+	mockMgr.On("GetProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Session == "sess-stream"
+	})).Return(sess, true).Once()
+
+	c, rec := buildStreamHTTPRequest(t, http.MethodGet, "", map[string]string{"Mcp-Session-Id": "sess-stream"})
+
+	// 异步注入：一条 response（应被 drop）+ 一条 notification（应被转发）
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		sess.SendEvent(service.SessionMsg{
+			Event: "message",
+			Data:  `{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`,
+		})
+		time.Sleep(20 * time.Millisecond)
+		sess.SendEvent(service.SessionMsg{
+			Event: "message",
+			Data:  `{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","logger":"test","data":"hi"}}`,
+		})
+		time.Sleep(20 * time.Millisecond)
+		// 触发 handler 退出
+		c.Request().Context()
+	}()
+
+	// 手工在 80ms 后关闭 context 让 handler 退出
+	ctx, cancel := context.WithCancel(c.Request().Context())
+	c.SetRequest(c.Request().WithContext(ctx))
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+
+	body := rec.Body.String()
+	// response 不应出现
+	assert.NotContains(t, body, `"result":{"tools":[]}`)
+	// notification 应被转发
+	assert.Contains(t, body, `notifications/message`)
+
+	mockMgr.AssertExpectations(t)
+}
+
+// --- request 转发并等待响应：外部注入 SendEvent 模拟下游响应 ---
+func TestGlobalStreamHTTP_Request_ForwardAndWait(t *testing.T) {
+	srv, mockMgr := createTestServerManager()
+
+	sess := newTestSession("sess-fw")
+	mockMgr.On("GetProxySession", mock.Anything, mock.MatchedBy(func(n service.NameArg) bool {
+		return n.Session == "sess-fw"
+	})).Return(sess, true).Once()
+
+	body := `{"jsonrpc":"2.0","id":42,"method":"tools/list"}`
+	c, rec := buildStreamHTTPRequest(t, http.MethodPost, body, map[string]string{"Mcp-Session-Id": "sess-fw"})
+
+	// handler 订阅 eventChan 后会异步等待响应：此 goroutine 延迟注入一条响应
+	go func() {
+		// 留出 handler 订阅与发送 SendMessage 的时间窗口
+		time.Sleep(50 * time.Millisecond)
+		sess.SendEvent(service.SessionMsg{
+			Event: "message",
+			Data:  `{"jsonrpc":"2.0","id":42,"result":{"tools":[]}}`,
+		})
+	}()
+
+	err := srv.handleGlobalStreamHTTP(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 42, resp["id"])
+	assert.NotNil(t, resp["result"])
+
+	mockMgr.AssertExpectations(t)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -55,8 +55,9 @@ type McpService struct {
 	RetryCount int
 	RetryMax   int
 
-	// stdio-sse bridge
-	bridge *bridge.StdioToSSEBridge
+	// bridge
+	bridge bridge.Bridge
+	isSSE  bool
 
 	// 状态详情
 	LastError      string    // 最后一次错误信息
@@ -178,13 +179,24 @@ func (s *McpService) Start(logger xlog.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
-	bridgeInstance, err := bridge.NewStdioToSSEBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+	var bridgeInstance bridge.Bridge
+	if s.Config.GatewayProtocol == "streamhttp" {
+		bridgeInstance, err = bridge.NewStdioToHTTPStreamBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+		if err == nil {
+			s.isSSE = false
+		}
+	} else {
+		bridgeInstance, err = bridge.NewStdioToSSEBridge(ctx, transport.NewStdio(s.Config.Command, s.Config.GetEnvs(), s.Config.Args...), s.Name)
+		if err == nil {
+			s.isSSE = true
+		}
+	}
 	if err != nil {
 		logger.Warnf("close logfile: %v", logFile.Close())
-		s.LastError = fmt.Sprintf("failed to create stdio-sse bridge: %v", err)
+		s.LastError = fmt.Sprintf("failed to create bridge: %v", err)
 		s.FailureReason = "Bridge creation failed"
 		s.Status = Failed
-		return fmt.Errorf("failed to create stdio-sse bridge: %w", err)
+		return fmt.Errorf("failed to create bridge: %w", err)
 	}
 
 	s.bridge = bridgeInstance
@@ -321,22 +333,27 @@ func (s *McpService) GetUrl() string {
 	return ""
 }
 
-// SSE
 func (s *McpService) GetSSEUrl() string {
 	if s.GetStatus() != Running {
 		return ""
 	}
-	sseUrl, _ := s.bridge.CompleteSseEndpoint()
-	return s.GetUrl() + sseUrl
+	if s.isSSE {
+		sseUrl, _ := s.bridge.(bridge.SSEBridge).CompleteSseEndpoint()
+		return s.GetUrl() + sseUrl
+	}
+	return ""
 }
 
-// Message
 func (s *McpService) GetMessageUrl() string {
 	if s.GetStatus() != Running {
 		return ""
 	}
-	mesUrl, _ := s.bridge.CompleteMessageEndpoint()
-	return s.GetUrl() + mesUrl
+	if s.isSSE {
+		mesUrl, _ := s.bridge.(bridge.SSEBridge).CompleteMessageEndpoint()
+		return s.GetUrl() + mesUrl
+	}
+	httpUrl, _ := s.bridge.(bridge.HTTPStreamBridge).CompleteHTTPStreamEndpoint()
+	return s.GetUrl() + httpUrl
 }
 
 func (s *McpService) GetPort() int {

--- a/service/session.go
+++ b/service/session.go
@@ -797,3 +797,71 @@ func (s *Session) IsReady() bool {
 	}
 	return true
 }
+
+// AggregateCapabilities OR-合并所有已订阅下游 MCP 在 initialize 时声明的
+// capabilities，用于网关自身对 client 的 capability 声明。只会声明至少有一个
+// 下游真的支持的能力，避免 client 依据网关声明发出下游全都不支持的请求。
+func (s *Session) AggregateCapabilities() mcp.ServerCapabilities {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var caps mcp.ServerCapabilities
+	for _, r := range s.mcpinitializeResults {
+		if r == nil {
+			continue
+		}
+		mergeCapabilities(&caps, r.Capabilities)
+	}
+	return caps
+}
+
+// mergeCapabilities 把 src 中声明的能力 OR 合并到 dst 中。
+func mergeCapabilities(dst *mcp.ServerCapabilities, src mcp.ServerCapabilities) {
+	if src.Tools != nil {
+		if dst.Tools == nil {
+			dst.Tools = &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{}
+		}
+		if src.Tools.ListChanged {
+			dst.Tools.ListChanged = true
+		}
+	}
+	if src.Prompts != nil {
+		if dst.Prompts == nil {
+			dst.Prompts = &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{}
+		}
+		if src.Prompts.ListChanged {
+			dst.Prompts.ListChanged = true
+		}
+	}
+	if src.Resources != nil {
+		if dst.Resources == nil {
+			dst.Resources = &struct {
+				Subscribe   bool `json:"subscribe,omitempty"`
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{}
+		}
+		if src.Resources.Subscribe {
+			dst.Resources.Subscribe = true
+		}
+		if src.Resources.ListChanged {
+			dst.Resources.ListChanged = true
+		}
+	}
+	if src.Logging != nil && dst.Logging == nil {
+		dst.Logging = &struct{}{}
+	}
+	if len(src.Experimental) > 0 {
+		if dst.Experimental == nil {
+			dst.Experimental = map[string]any{}
+		}
+		for k, v := range src.Experimental {
+			if _, exists := dst.Experimental[k]; !exists {
+				dst.Experimental[k] = v
+			}
+		}
+	}
+}

--- a/service/session_test.go
+++ b/service/session_test.go
@@ -319,3 +319,117 @@ func TestSessionCustomCleanupConfig(t *testing.T) {
 		t.Fatalf("expected cleanup callback to be triggered after custom TTL")
 	}
 }
+
+// mergeInitializeResult 写入 session 的 mcpinitializeResults，供 AggregateCapabilities 测试使用。
+func (s *Session) setInitializeResultForTest(name string, r *mcp.InitializeResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mcpinitializeResults[name] = r
+}
+
+func TestSession_AggregateCapabilities_Empty(t *testing.T) {
+	s := NewSession("aggr-empty")
+	defer s.Close()
+
+	caps := s.AggregateCapabilities()
+	if caps.Tools != nil || caps.Prompts != nil || caps.Resources != nil || caps.Logging != nil || caps.Experimental != nil {
+		t.Errorf("expected empty capabilities, got %+v", caps)
+	}
+}
+
+func TestSession_AggregateCapabilities_OnlyDeclaresWhenAtLeastOneDownstreamHasIt(t *testing.T) {
+	s := NewSession("aggr-some")
+	defer s.Close()
+
+	s.setInitializeResultForTest("m1", &mcp.InitializeResult{
+		Capabilities: mcp.ServerCapabilities{
+			Tools: &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{ListChanged: false},
+		},
+	})
+	s.setInitializeResultForTest("m2", &mcp.InitializeResult{
+		Capabilities: mcp.ServerCapabilities{}, // 无能力声明
+	})
+
+	caps := s.AggregateCapabilities()
+	if caps.Tools == nil {
+		t.Errorf("expected Tools declared because m1 has it")
+	}
+	if caps.Logging != nil {
+		t.Errorf("expected Logging nil because no downstream declared it, got %+v", caps.Logging)
+	}
+	if caps.Prompts != nil {
+		t.Errorf("expected Prompts nil, got %+v", caps.Prompts)
+	}
+	if caps.Resources != nil {
+		t.Errorf("expected Resources nil, got %+v", caps.Resources)
+	}
+}
+
+func TestSession_AggregateCapabilities_ORsAcrossDownstreams(t *testing.T) {
+	s := NewSession("aggr-or")
+	defer s.Close()
+
+	s.setInitializeResultForTest("m1", &mcp.InitializeResult{
+		Capabilities: mcp.ServerCapabilities{
+			Tools: &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{ListChanged: false},
+			Resources: &struct {
+				Subscribe   bool `json:"subscribe,omitempty"`
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{Subscribe: true, ListChanged: false},
+		},
+	})
+	s.setInitializeResultForTest("m2", &mcp.InitializeResult{
+		Capabilities: mcp.ServerCapabilities{
+			Tools: &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{ListChanged: true},
+			Prompts: &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{ListChanged: true},
+			Logging: &struct{}{},
+			Experimental: map[string]any{
+				"foo": "bar",
+			},
+		},
+	})
+
+	caps := s.AggregateCapabilities()
+	if caps.Tools == nil || !caps.Tools.ListChanged {
+		t.Errorf("expected Tools.ListChanged=true after OR, got %+v", caps.Tools)
+	}
+	if caps.Prompts == nil || !caps.Prompts.ListChanged {
+		t.Errorf("expected Prompts.ListChanged=true, got %+v", caps.Prompts)
+	}
+	if caps.Resources == nil || !caps.Resources.Subscribe {
+		t.Errorf("expected Resources.Subscribe=true, got %+v", caps.Resources)
+	}
+	if caps.Logging == nil {
+		t.Errorf("expected Logging declared")
+	}
+	if caps.Experimental["foo"] != "bar" {
+		t.Errorf("expected Experimental[foo]=bar, got %+v", caps.Experimental)
+	}
+}
+
+func TestSession_AggregateCapabilities_IgnoresNilResults(t *testing.T) {
+	s := NewSession("aggr-nil")
+	defer s.Close()
+
+	s.setInitializeResultForTest("m-nil", nil)
+	s.setInitializeResultForTest("m1", &mcp.InitializeResult{
+		Capabilities: mcp.ServerCapabilities{
+			Tools: &struct {
+				ListChanged bool `json:"listChanged,omitempty"`
+			}{ListChanged: true},
+		},
+	})
+
+	caps := s.AggregateCapabilities()
+	if caps.Tools == nil || !caps.Tools.ListChanged {
+		t.Errorf("expected Tools.ListChanged=true, nil result should be skipped; got %+v", caps.Tools)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GatewayProtocol` config field to choose between SSE and StreamHTTP protocols
- Support `--protocol` command line argument to override config at startup
- Add bridge interface abstraction for SSEBridge and HTTPStreamBridge
- Service layer selects bridge based on protocol configuration
- Router registers endpoints based on selected protocol

## Usage

```bash
# SSE mode (default)
./mcp-gateway

# StreamHTTP mode
./mcp-gateway --protocol=streamhttp
```

Or via config.json:
```json
{
  "GatewayProtocol": "streamhttp"
}
```

## Files Changed

- `config/config.go` - Add GatewayProtocol field and IsStreamHTTP() method
- `main.go` - Add --protocol command line argument
- `bridge/bridge.go` - New interface definitions
- `bridge/stdio_to_sse.go` - Add CompleteSseEndpoint/CompleteMessageEndpoint methods
- `bridge/stdio_to_http_stream.go` - Add CompleteHTTPStreamEndpoint method
- `service/service.go` - Support protocol-based bridge selection
- `router/server.go` - Conditional route registration
- `router/streamhttp.go` - New StreamHTTP handler